### PR TITLE
Adds regex validation for ppc64le architecture

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -138,7 +138,7 @@ define mrepo::repo (
   include mrepo::params
 
   validate_re($ensure, "^present$|^absent$")
-  validate_re($arch, "^i386$|^i586$|^x86_64$|^ppc$|^s390$|^s390x$|^ia64$")
+  validate_re($arch, "^i386$|^i586$|^x86_64$|^ppc$|^ppc64le$|^s390$|^s390x$|^ia64$")
   validate_re($update, "^now$|^nightly$|^weekly$|^never$")
   validate_re($type  , "^std$|^ncc$|^rhn$")
 


### PR DESCRIPTION
Modified `manifests/repo.pp` and added a regex statement for validating `ppc64le` architecture when used in the `$arch` param.